### PR TITLE
Add Gemini API

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -316,6 +316,8 @@ module "api_management" {
   event_hub_name                                          = module.event_hub.event_hub_central_name
   zones                                                   = var.apim.zones
   log_analytics_workspace_id                              = module.log_analytics.log_analytics_workspace_id
+  gemini_api_key                                          = var.gemini_api_key
+  gemini_openapi_specification_url                        = var.gemini_openapi_specification_url
 }
 
 # ------------------------------------------------------------------------------------------------------

--- a/infra/modules/api_management/apis.tf
+++ b/infra/modules/api_management/apis.tf
@@ -13,3 +13,19 @@ resource "azurerm_api_management_api" "openai_api" {
   subscription_required = true
   api_type              = "http"
 }
+
+resource "azurerm_api_management_api" "gemini_api" {
+  name                = "Gemini"
+  resource_group_name = var.resource_group_name
+  api_management_name = azurerm_api_management.api_management.name
+  revision            = "1"
+  display_name        = "Google Gemini"
+  path                = "gemini"
+  protocols           = ["https"]
+  import {
+    content_format = "openapi-link"
+    content_value  = var.gemini_openapi_specification_url
+  }
+  subscription_required = true
+  api_type              = "http"
+}

--- a/infra/modules/api_management/named_values.tf
+++ b/infra/modules/api_management/named_values.tf
@@ -92,3 +92,12 @@ resource "azurerm_api_management_named_value" "openai_semantic_cache_store_durat
   value               = var.openai_semantic_cache_store_duration
   secret              = false
 }
+
+resource "azurerm_api_management_named_value" "gemini_api_key" {
+  api_management_name = azurerm_api_management.api_management.name
+  name                = "gemini-api-key"
+  resource_group_name = var.resource_group_name
+  display_name        = "gemini-api-key"
+  value               = var.gemini_api_key
+  secret              = true
+}

--- a/infra/modules/api_management/policies.tf
+++ b/infra/modules/api_management/policies.tf
@@ -17,6 +17,16 @@ resource "azurerm_api_management_api_policy" "openai_api_policy" {
   ]
 }
 
+resource "azurerm_api_management_api_policy" "gemini_api_policy" {
+  api_management_name = azurerm_api_management.api_management.name
+  resource_group_name = var.resource_group_name
+  api_name            = azurerm_api_management_api.gemini_api.name
+  xml_content         = file("${path.module}/policies/gemini.xml")
+  depends_on = [
+    azurerm_api_management_named_value.gemini_api_key
+  ]
+}
+
 resource "azurerm_api_management_policy_fragment" "generate_partition_key_policy" {
   api_management_id = azurerm_api_management.api_management.id
   name              = "generate-partition-key"

--- a/infra/modules/api_management/policies/gemini.xml
+++ b/infra/modules/api_management/policies/gemini.xml
@@ -1,0 +1,38 @@
+<policies>
+    <inbound>
+        <base />
+        <set-header name="x-goog-api-key" exists-action="override">
+            <value>{{gemini-api-key}}</value>
+        </set-header>
+        <cors allow-credentials="true">
+            <allowed-origins>
+                <origin>*</origin>
+            </allowed-origins>
+            <allowed-methods>
+                <method>GET</method>
+                <method>POST</method>
+                <method>PUT</method>
+                <method>DELETE</method>
+                <method>HEAD</method>
+                <method>OPTIONS</method>
+                <method>PATCH</method>
+                <method>TRACE</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>*</header>
+            </allowed-headers>
+            <expose-headers>
+                <header>*</header>
+            </expose-headers>
+        </cors>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/infra/modules/api_management/variables.tf
+++ b/infra/modules/api_management/variables.tf
@@ -168,3 +168,14 @@ variable "log_analytics_workspace_id" {
   description = "The Log Analytics workspace ID to use for the API Management service"
   type        = string
 }
+
+variable "gemini_api_key" {
+  description = "The Google Gemini API key to use for authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "gemini_openapi_specification_url" {
+  description = "The Google Gemini Swagger URL to use for the API Management service"
+  type        = string
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -129,6 +129,17 @@ variable "function_app" {
   })
 }
 
+variable "gemini_api_key" {
+  description = "The Google Gemini API key to use for authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "gemini_openapi_specification_url" {
+  description = "The Google Gemini Swagger URL to use for the API Management service"
+  type        = string
+}
+
 # variable "virtual_network_resource_group_name" {
 #   description = "The resource group name of the virtual network"
 #   type        = string


### PR DESCRIPTION
Added Google Gemini API to APIM with the following minimal changes:

- Created new Gemini API definition in APIM
- Set up API key authentication via named value for simple dev env access
- Added XML policy to apply the Google API key to all requests (may need to be modified depending on requirements)
- Added required variables for Gemini API key and OpenAPI specification URL
- Configured subscription requirements matching existing OpenAI pattern (may need to be modified depending on requirements)
